### PR TITLE
Fix "ImportError: No module named packaging.version" error with latest setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,23 +5,25 @@ RUN apt-get update && apt-get install -y \
     -o APT::Install-Suggests=false \
     git \
     python-dev \
-    python-pip \
     python-virtualenv \
     libmpfr-dev \
     libssl-dev \
     libmpc-dev \
-    libffi-dev 
+    libffi-dev
 #    build-essential \
 #    libpython-dev
+RUN apt-get install -y wget gcc
+RUN wget -O /tmp/get-pip.py "https://bootstrap.pypa.io/get-pip.py"
+RUN python /tmp/get-pip.py --no-setuptools
+RUN pip install setuptools==33.1.1
 RUN groupadd cowrie
 RUN useradd -d /cowrie -m -g cowrie cowrie
-RUN pip install packaging
 USER cowrie
 
 RUN git clone -b develop http://github.com/micheloosterhof/cowrie /cowrie/cowrie-git
 WORKDIR /cowrie/cowrie-git
 RUN virtualenv cowrie-env
-RUN . cowrie-env/bin/activate; pip install -r ~cowrie/cowrie-git/requirements.txt
+RUN . cowrie-env/bin/activate; pip install setuptools==33.1.1; pip install -r ~cowrie/cowrie-git/requirements.txt
 RUN cp ~cowrie/cowrie-git/etc/cowrie.cfg.dist ~cowrie/cowrie-git/etc/cowrie.cfg
 
 CMD /cowrie/cowrie-git/bin/cowrie start -n

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
 #    libpython-dev
 RUN groupadd cowrie
 RUN useradd -d /cowrie -m -g cowrie cowrie
+RUN pip install packaging
 USER cowrie
 
 RUN git clone -b develop http://github.com/micheloosterhof/cowrie /cowrie/cowrie-git


### PR DESCRIPTION
This patch fixes the docker recipe caused by the latest version (34) of setuptools