### PR TITLE
Create a smaller image and add a docker-compose sample.

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=cowrie

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,58 @@
-FROM debian
+FROM debian:jessie-slim
 MAINTAINER Michel Oosterhof <michel@oosterhof.net>
+
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y \
-    -o APT::Install-Suggests=false \
-    git \
-    python-dev \
-    python-pip \
-    python-virtualenv \
-    libmpfr-dev \
-    libssl-dev \
-    libmpc-dev \
-    libffi-dev 
-#    build-essential \
-#    libpython-dev
-RUN groupadd cowrie
-RUN useradd -d /cowrie -m -g cowrie cowrie
+
+RUN apt-get update && \
+    apt-get upgrade && \
+    apt-get install -y -o APT::Install-Suggests=false \
+      python-pip \
+      libmpfr-dev \
+      libssl-dev \
+      libmpc-dev \
+      libffi-dev \
+      build-essential \
+      libpython-dev \
+      python2.7-minimal \
+      git \
+      python-virtualenv \
+      python-setuptools && \
+    #
+    # Add a user and group run run under.
+    groupadd cowrie && \
+    useradd -d /cowrie -m -g cowrie cowrie && \
+    #
+    # Build a cowrie environment from github develop HEAD.
+    su - cowrie -c "\
+      git clone -b develop http://github.com/micheloosterhof/cowrie /cowrie/cowrie-git && \
+      cd /cowrie/cowrie-git && \
+        virtualenv cowrie-env && \
+        . cowrie-env/bin/activate && \
+        pip install --upgrade cffi && \
+        pip install -r ~cowrie/cowrie-git/requirements.txt && \
+        cp ~cowrie/cowrie-git/etc/cowrie.cfg.dist ~cowrie/cowrie-git/etc/cowrie.cfg" && \
+    #
+    # Remove all the build tools to keep the image small.
+    apt-get remove -y --purge \
+      git \
+      python-pip \
+      python-setuptools \
+      libmpfr-dev \
+      libssl-dev \
+      libmpc-dev \
+      libffi-dev \
+      build-essential \
+      libpython-dev \
+      python3.4* && \
+    #
+    # Remove any auto-installed depends for the build and any temp files and package lists.
+    apt-get autoremove -y && \
+    dpkg -l | awk '/^rc/ {print $2}' | xargs dpkg --purge && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 USER cowrie
-
-RUN git clone -b develop http://github.com/micheloosterhof/cowrie /cowrie/cowrie-git
 WORKDIR /cowrie/cowrie-git
-RUN virtualenv cowrie-env
-RUN . cowrie-env/bin/activate; pip install -r ~cowrie/cowrie-git/requirements.txt
-RUN cp ~cowrie/cowrie-git/etc/cowrie.cfg.dist ~cowrie/cowrie-git/etc/cowrie.cfg
-
 CMD /cowrie/cowrie-git/bin/cowrie start -n
-
-VOLUME /cowrie/cowrie-git/var
-VOLUME /cowrie/cowrie-git/etc
-EXPOSE 2222
-EXPOSE 2223
+EXPOSE 2222 2223
+VOLUME [ "/cowrie/cowrie-git/etc", "/cowrie/cowrie-git/var" ]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ Honeypot Docker effort. It contains Dockerfiles that you can use
 to build [Cowrie](https://github.com/micheloosterhof/cowrie)
 Docker images.
 
+# docker-compose volumes
+
+If you want to map local directories into the docker image, you need
+to make sure that the direcories cowrie expects already exist, or it
+will start failing in a never-ending loop.
+
+```
+mkdir -p var/log/cowrie var/run
+```
+
 # What is Cowrie 
 
 Cowrie is a medium interaction SSH and Telnet honeypot designed to

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,8 @@ services:
     ports:
       - "2222:2222"
       - "2223:2223"
+    volumes:
+      # Map a local cowrie config dir into the container.
+      # - "./etc:/cowrie/cowrie-git/etc"
+      # Make cowrie logs persistent through container recreates.
+      - "./var:/cowrie/cowrie-git/var"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "2.0"
+
+services:
+  cowrie:
+    restart: always
+    # Bug Michel to create a Docker Hub account and build an image from the repo.
+    # build: .
+    image: cafuego/cowrie:dev
+    ports:
+      - "2222:2222"
+      - "2223:2223"


### PR DESCRIPTION
All in the name of making things easier to use!

With a working Dockerfile, it would also be possible to have DockerHub automatically build updated images on GitHub repo push. Isn't that nice.