### PR TITLE
Upgrade pip and setuptools fixes a build problem (fixes #9)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN su - cowrie -c "\
         virtualenv cowrie-env && \
         . cowrie-env/bin/activate && \
         pip install --upgrade cffi && \
+        pip install --upgrade pip && \
+        pip install --upgrade setuptools && \
         pip install -r ~cowrie/cowrie-git/requirements.txt" && \
 
     # Remove all the build tools to keep the image small.


### PR DESCRIPTION
Fixes "Invalid environment marker: python_version < '3'" on cryptography module install.

Related: https://github.com/micheloosterhof/cowrie/issues/599